### PR TITLE
Fix SDL setup when TFT HAT exposes only fb0

### DIFF
--- a/src/tft_env.py
+++ b/src/tft_env.py
@@ -1,13 +1,38 @@
-"""
-If /dev/fb1 exists (typical on 3.5" TFT HATs), direct pygame to it.
-Otherwise fall back to default display (HDMI/KMS).
-"""
-import os
+"""Helpers for configuring pygame/SDL to talk to TFT framebuffers."""
 
-def configure_sdl_env():
-    if os.path.exists("/dev/fb1"):
-        os.environ.setdefault("SDL_VIDEODRIVER", "fbcon")
-        os.environ.setdefault("SDL_FBDEV", "/dev/fb1")
-        # Touch input paths vary; these hints are harmless if absent.
-        os.environ.setdefault("SDL_MOUSEDRV", "TSLIB")
-        os.environ.setdefault("SDL_MOUSEDEV", "/dev/input/touchscreen")
+import os
+from typing import Iterable
+
+
+def _apply_fb_settings(fb_path: str) -> None:
+    os.environ.setdefault("SDL_VIDEODRIVER", "fbcon")
+    os.environ.setdefault("SDL_FBDEV", fb_path)
+    # Touch input paths vary; these hints are harmless if absent.
+    os.environ.setdefault("SDL_MOUSEDRV", "TSLIB")
+    os.environ.setdefault("SDL_MOUSEDEV", "/dev/input/touchscreen")
+
+
+def _existing_paths(paths: Iterable[str]) -> list[str]:
+    return [p for p in paths if os.path.exists(p)]
+
+
+def configure_sdl_env() -> None:
+    """Try to steer SDL toward whichever framebuffer the TFT exposes.
+
+    On some Raspberry Pi configurations the HAT shows up as ``/dev/fb1`` while
+    the primary framebuffer is still ``/dev/fb0``.  Other stacks (notably the
+    VC4/KMS default on Pi 4) expose only ``/dev/fb0``.  When pygame falls back
+    to the ``kmsdrm`` backend without a proper ``XDG_RUNTIME_DIR`` it aborts
+    before we even get a window.  Steering SDL to the classic ``fbcon`` driver
+    works reliably in these kiosk-style setups, so we do that whenever we spot
+    a usable framebuffer device.
+    """
+
+    for fb in _existing_paths(("/dev/fb1", "/dev/fb0")):
+        _apply_fb_settings(fb)
+        break
+
+    # Some drivers (kmsdrm) insist on XDG_RUNTIME_DIR even when they do not
+    # end up being used.  If the service is running without a login session we
+    # provide a safe default so SDL does not crash during initialization.
+    os.environ.setdefault("XDG_RUNTIME_DIR", "/tmp")


### PR DESCRIPTION
## Summary
- steer SDL toward whichever framebuffer device (fb1 or fb0) the TFT exposes
- provide a safe default XDG_RUNTIME_DIR so pygame will start under systemd

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68dc88c371e08321aa1b84346dd79cf7