### PR TITLE
Add service wrapper script for resilient execution

### DIFF
--- a/scripts/run_service.sh
+++ b/scripts/run_service.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+VENV_PY="${ROOT_DIR}/.venv/bin/python"
+if [ -x "${VENV_PY}" ]; then
+  PYTHON_BIN="${VENV_PY}"
+else
+  PYTHON_BIN="$(command -v python3)"
+fi
+
+export PYTHONUNBUFFERED=1
+export XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR:-/tmp}"
+
+# Hint SDL toward the TFT framebuffer if one is present.
+if [ -z "${SDL_VIDEODRIVER:-}" ]; then
+  export SDL_VIDEODRIVER=fbcon
+fi
+if [ -z "${SDL_FBDEV:-}" ]; then
+  if [ -e /dev/fb1 ]; then
+    export SDL_FBDEV=/dev/fb1
+  elif [ -e /dev/fb0 ]; then
+    export SDL_FBDEV=/dev/fb0
+  fi
+fi
+
+exec "${PYTHON_BIN}" -m src.camera_viewer "$@"

--- a/systemd/endoscope-viewer.service
+++ b/systemd/endoscope-viewer.service
@@ -7,7 +7,7 @@ Type=simple
 User=__USER__
 WorkingDirectory=__WORKDIR__
 Environment=PYTHONUNBUFFERED=1
-ExecStart=__WORKDIR__/.venv/bin/python -m src.camera_viewer --rotate 90
+ExecStart=__WORKDIR__/scripts/run_service.sh --rotate 90
 Restart=always
 RestartSec=1
 


### PR DESCRIPTION
## Summary
- add a run_service.sh helper that prefers the project virtual environment but falls back to system python
- set minimal SDL and XDG environment defaults before launching the camera viewer
- update the systemd unit to call the helper script instead of hard-coding the venv python path

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dc8d279790832199620ed1dea971e4