### PR TITLE
Improve service diagnostics and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,62 @@
 # pi-endoscope-tft (simple)
 
-Tiny viewer that opens a USB endoscope (UVC) on a Raspberry Pi and displays it full-screen on an Inland/Waveshare-style 3.5" TFT HAT (fb1).  
-If `/dev/fb1` isn’t present, it renders to the default display (HDMI).
+Tiny viewer that opens a USB endoscope (UVC) on a Raspberry Pi and displays it
+full-screen on an Inland/Waveshare-style 3.5" TFT HAT. If `/dev/fb1` is not
+present, it renders to the default display (HDMI).
 
 ## Install (on the Pi)
+
 ```bash
 git clone https://github.com/lukehami55/frisbee.git
 cd frisbee
 sudo ./scripts/install.sh
+```
+
+The installer will:
+
+* create/update a Python virtual environment in the repo (`.venv`)
+* install the `endoscope-viewer.service` unit, pointing it at the
+  `scripts/run_service.sh` wrapper
+* restart the service so the new bits take effect immediately
+
+## Updating an existing install
+
+After pulling new code, re-run the installer so the service picks up any
+changes:
+
+```bash
+cd /home/pi/frisbee
+git pull
+sudo ./scripts/install.sh
+```
+
+That ensures the systemd unit and virtualenv match the working tree. If you
+prefer to update the service manually, copy
+`systemd/endoscope-viewer.service` to `/etc/systemd/system/`, replace the
+`__USER__`/`__WORKDIR__` placeholders, then run `sudo systemctl daemon-reload`
+followed by `sudo systemctl restart endoscope-viewer.service`.
+
+## Troubleshooting
+
+* Check the logs while the service runs:
+
+  ```bash
+  sudo journalctl -u endoscope-viewer.service -f
+  ```
+
+  The `run_service.sh` wrapper and the viewer now print their configuration
+  decisions (which interpreter is used, SDL framebuffer selection, camera
+  device, etc.) to make it easier to spot misconfigurations.
+
+* If the service complains about missing Python modules, the virtualenv may not
+  have been created. Re-run `sudo ./scripts/install.sh`.
+
+* To experiment interactively without the service, activate the virtualenv and
+  run the viewer by hand:
+
+  ```bash
+  source .venv/bin/activate
+  python -m src.camera_viewer --debug
+  ```
+
+  Use `Ctrl+C` or tap the screen twice quickly to exit.

--- a/scripts/run_service.sh
+++ b/scripts/run_service.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+log() {
+  echo "[run_service] $*" >&2
+}
+
+VENV_PY="${ROOT_DIR}/.venv/bin/python"
+if [ -x "${VENV_PY}" ]; then
+  PYTHON_BIN="${VENV_PY}"
+  log "Using project virtualenv at ${PYTHON_BIN}"
+else
+  PYTHON_BIN="$(command -v python3 || true)"
+  if [ -n "${PYTHON_BIN}" ]; then
+    log "Virtualenv missing; falling back to ${PYTHON_BIN}"
+  else
+    log "ERROR: Could not find a python3 interpreter"
+    exit 1
+  fi
+fi
+
+export PYTHONUNBUFFERED=1
+export XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR:-/tmp}"
+
+# Hint SDL toward the TFT framebuffer if one is present.
+if [ -z "${SDL_VIDEODRIVER:-}" ]; then
+  export SDL_VIDEODRIVER=fbcon
+  log "SDL_VIDEODRIVER defaulted to fbcon"
+else
+  log "SDL_VIDEODRIVER pre-set to ${SDL_VIDEODRIVER}"
+fi
+if [ -z "${SDL_FBDEV:-}" ]; then
+  if [ -e /dev/fb1 ]; then
+    export SDL_FBDEV=/dev/fb1
+  elif [ -e /dev/fb0 ]; then
+    export SDL_FBDEV=/dev/fb0
+  fi
+  if [ -n "${SDL_FBDEV:-}" ]; then
+    log "SDL_FBDEV defaulted to ${SDL_FBDEV}"
+  else
+    log "No framebuffer override detected"
+  fi
+else
+  log "SDL_FBDEV pre-set to ${SDL_FBDEV}"
+fi
+
+log "Launching camera viewer (${PYTHON_BIN} -m src.camera_viewer $*)"
+exec "${PYTHON_BIN}" -m src.camera_viewer "$@"

--- a/src/camera_viewer.py
+++ b/src/camera_viewer.py
@@ -4,7 +4,7 @@ Simple full-screen viewer for a USB UVC endoscope.
 - Exit: press 'q' or double-tap the touch screen quickly.
 """
 from __future__ import annotations
-import argparse, time
+import argparse, sys, time
 import cv2, pygame
 from .device_match import pick_best_device
 from .tft_env import configure_sdl_env
@@ -49,8 +49,16 @@ def main():
     configure_sdl_env()
     args = parse_args()
 
+    print(
+        f"[viewer] Starting with rotate={args.rotate}, mirror={args.mirror}, "
+        f"target={args.width}x{args.height}@{args.fps}",
+        file=sys.stderr,
+    )
+
     dev = pick_best_device(args.device)
+    print(f"[viewer] Opening camera device {dev}", file=sys.stderr)
     cap = open_cam(dev, args.width, args.height, args.fps)
+    print("[viewer] Camera opened successfully", file=sys.stderr)
 
     pygame.init()
     screen = pygame.display.set_mode((0, 0), pygame.FULLSCREEN)

--- a/src/tft_env.py
+++ b/src/tft_env.py
@@ -1,6 +1,7 @@
 """Helpers for configuring pygame/SDL to talk to TFT framebuffers."""
 
 import os
+import sys
 from typing import Iterable
 
 
@@ -28,11 +29,20 @@ def configure_sdl_env() -> None:
     a usable framebuffer device.
     """
 
+    chosen_fb = None
     for fb in _existing_paths(("/dev/fb1", "/dev/fb0")):
         _apply_fb_settings(fb)
+        chosen_fb = fb
         break
+
+    if chosen_fb:
+        print(f"[tft_env] SDL steering to framebuffer {chosen_fb}", file=sys.stderr)
+    else:
+        print("[tft_env] No framebuffer override detected; using SDL defaults", file=sys.stderr)
 
     # Some drivers (kmsdrm) insist on XDG_RUNTIME_DIR even when they do not
     # end up being used.  If the service is running without a login session we
     # provide a safe default so SDL does not crash during initialization.
-    os.environ.setdefault("XDG_RUNTIME_DIR", "/tmp")
+    if "XDG_RUNTIME_DIR" not in os.environ:
+        os.environ["XDG_RUNTIME_DIR"] = "/tmp"
+        print("[tft_env] XDG_RUNTIME_DIR defaulted to /tmp", file=sys.stderr)

--- a/systemd/endoscope-viewer.service
+++ b/systemd/endoscope-viewer.service
@@ -7,7 +7,7 @@ Type=simple
 User=__USER__
 WorkingDirectory=__WORKDIR__
 Environment=PYTHONUNBUFFERED=1
-ExecStart=__WORKDIR__/.venv/bin/python -m src.camera_viewer --rotate 90
+ExecStart=__WORKDIR__/scripts/run_service.sh --rotate 90
 Restart=always
 RestartSec=1
 


### PR DESCRIPTION
## Summary
- add logging to the service wrapper, SDL helper, and viewer so journald shows how the app is configured
- document reinstall/update steps and troubleshooting tips in the README

## Testing
- bash -n scripts/run_service.sh

------
https://chatgpt.com/codex/tasks/task_e_68dc8d279790832199620ed1dea971e4